### PR TITLE
Makefile for Unix systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,12 @@
 cc65/
 libsrc/
 temp/runtime/
-temp/*.o
 temp/*.s
-temp/*.dbg
-temp/*.map
 temp/*.lst
-temp/*.nes
 *.opt
 cmd.exe.lnk
+dgolf.c.s
+*.o
+*.dbg
+*.map
+*.nes

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,25 @@
+PROGRAM=dgolf
+
+CC=cc65
+AS=ca65
+LD=ld65
+
+CFLAGS=-O -T -g
+ASFLAGS=-g
+LDFLAGS=-m $(PROGRAM).map --dbgfile $(PROGRAM).dbg -C $(PROGRAM).cfg
+
+.PHONE: all clean
+
+all: $(PROGRAM).nes
+
+%.o: %.s
+	$(AS) -o $@ $(ASFLAGS) $<
+
+%.c.s: %.c
+	$(CC) -o $@ $(CFLAGS) $<
+
+$(PROGRAM).nes: blend.o dgolf.o dgolf.c.o dgolf.c.s
+	$(LD) -o $@ $(LDFLAGS) blend.o $(PROGRAM).o $(PROGRAM).c.o temp/runtime.lib
+
+clean:
+	$(RM) blend.o $(PROGRAM).c.o $(PROGRAM).c.s $(PROGRAM).dbg $(PROGRAM).map $(PROGRAM).nes $(PROGRAM).o


### PR DESCRIPTION
Basically does what "build.bat" does on Windows, but on Unix with cc65 in the $PATH, you can just type "make" and it'll output the NES file. If you even use the same cc65 version, it'll reproduce the released file byte-for-byte.